### PR TITLE
Add User Connection Limiting for VLESS Protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,17 +6,21 @@ Some confusing protocol.
 
 100% compatible with `v2ray-core`.
 
-* Stream length chunk with padding and masking
-* AEAD length chunk with padding
-* Stream chunk
-* AEAD chunk
-* Legacy client
-* AEAD client
-* Legacy server
-* AEAD server
+- Stream length chunk with padding and masking
+- AEAD length chunk with padding
+- Stream chunk
+- AEAD chunk
+- Legacy client
+- AEAD client
+- Legacy server
+- AEAD server
 
 Extra features:
 
-* Mux server
-* XUDP client
-* VLESS client
+- Mux server
+- XUDP client
+- VLESS client
+
+## Nothing changed Added a vless login limiter
+
+- Can limit how many user can connect using same uuid


### PR DESCRIPTION
This pull request introduces a new feature to the sing-vmess project, enabling the limitation of concurrent user connections using the same UUID. This feature has been implemented in the VLESS protocol, written in Go.

Changes:

Added a mechanism to restrict the number of users who can connect simultaneously with the same UUID.
This helps prevent misuse or excessive sharing of a single UUID among multiple users.
Introduced a configuration field that allows specifying the maximum number of concurrent connections for each UUID.
If the connection limit is exceeded, the server will reject further connection attempts for the UUID until all existing connections are closed.

Key Points:
This feature benefits all sing-box users by improving connection management.
The implementation does not introduce any latency to the connections.
Additionally, there is potential to add bandwidth limitation by wrapping the read and write methods on serverconn (not implemented in this PR).
Impact:

No existing codebase is affected.
There are no changes required on the client side.
Usage Example: In sing-box/inbound/vless.go, when you call service.UpdateUser(), an additional parameter for maxlogin should be passed.

Example User Configuration:

json
Copy code
"users": [
  {
    "name": "sekai",
    "uuid": "bf000d23-0752-40b4-affe-68f7707a9661",
    "flow": "",
    "maxlogin": 4
  },
  {
    "name": "name",
    "uuid": "1c9a5143-uieb-4cfd-b733-1f5e96edc949", // 2 users can connect simultaneously using this UUID
    "maxlogin": 2,
    "flow": ""
  },
  {
    "name": "name1",
    "uuid": "1ctyu143-bfeb-4cfd-b733-1f5e96edc949", // maxlogin defaults to 1
    "flow": ""
  }
]