### PR TITLE
Add VLESS route extraction from UUID bytes 6-7

### DIFF
--- a/vless/service.go
+++ b/vless/service.go
@@ -45,6 +45,8 @@ func (s *Service[T]) UpdateUsers(userList []T, userUUIDList []string, userFlowLi
 		if err != nil {
 			userID = uuid.NewV5(uuid.Nil, userUUIDList[i])
 		}
+		userID[6] = 0
+		userID[7] = 0
 		userMap[userID] = userName
 		userFlowMap[userName] = userFlowList[i]
 	}
@@ -57,11 +59,16 @@ func (s *Service[T]) NewConnection(ctx context.Context, conn net.Conn, source M.
 	if err != nil {
 		return err
 	}
-	user, loaded := s.userMap[request.UUID]
+	vlessRoute := binary.BigEndian.Uint16(request.UUID[6:8])
+	lookupUUID := request.UUID
+	lookupUUID[6] = 0
+	lookupUUID[7] = 0
+	user, loaded := s.userMap[lookupUUID]
 	if !loaded {
-		return E.New("unknown UUID: ", uuid.FromBytesOrNil(request.UUID[:]))
+		return E.New("unknown UUID: ", uuid.FromBytesOrNil(lookupUUID[:]))
 	}
 	ctx = auth.ContextWithUser(ctx, user)
+	ctx = ContextWithVLESSRoute(ctx, vlessRoute)
 	userFlow := s.userFlow[user]
 	if request.Flow == FlowVision && request.Command == vmess.NetworkUDP {
 		return E.New(FlowVision, " flow does not support UDP")

--- a/vless/vless_route.go
+++ b/vless/vless_route.go
@@ -1,0 +1,17 @@
+package vless
+
+import "context"
+
+type vlessRouteContextKey struct{}
+
+func ContextWithVLESSRoute(ctx context.Context, route uint16) context.Context {
+	return context.WithValue(ctx, (*vlessRouteContextKey)(nil), route)
+}
+
+func VLESSRouteFromContext(ctx context.Context) (uint16, bool) {
+	value := ctx.Value((*vlessRouteContextKey)(nil))
+	if value == nil {
+		return 0, false
+	}
+	return value.(uint16), true
+}


### PR DESCRIPTION
Extract a uint16 routing value from VLESS UUID bytes 6-7 (big-endian), inspired by Xray's `vlessRoute` feature.

## Changes
- `UpdateUsers()` zeros bytes 6-7 of stored UUIDs before map insertion
- `NewConnection()` extracts route value from incoming UUID bytes 6-7, zeros them in a copy for user lookup, keeps original UUID for vision
- Route value is passed to handler via `context.Context`